### PR TITLE
Added logic for header prefix

### DIFF
--- a/src/file_handling.c
+++ b/src/file_handling.c
@@ -13,6 +13,7 @@
 /*blksize_t st_blksize;     [> Block size for filesystem I/O <]*/
 /*blkcnt_t  st_blocks;      [> Number of 512B blocks allocated <]*/
 
+
 // S_ISDIR(stats.st_mode);
 
 void file_info(header_t *header, struct stat stats)
@@ -32,7 +33,7 @@ void file_info(header_t *header, struct stat stats)
 
 void add_mode(header_t *header, struct stat stats)
 {
-
+// ->  TODO:	The mode field provides nine bits specifying file permissions and three bits to specify the Set UID, Set GID, and Save Text (sticky) modes.
 	int mode = 0;
 
 	int modes[NUM_MODES] = {TUREAD, TUWRITE, TUEXEC, TGREAD, TGWRITE, TGEXEC, TOREAD, TOWRITE, TOEXEC};
@@ -45,16 +46,40 @@ void add_mode(header_t *header, struct stat stats)
 	my_itoa(header->mode, mode, OCTAL);
 }
 
+
+		/* TODO: double check -
+		 * The name field is the file name of the file, with directory names (if any) preceding the file name, separated by slashes. */
+void add_name(header_t *header, char *path)
+{
+   /* name is prefix if more than 100 char */
+  size_t path_len = strlen(path);
+  if(path_len < MAX_NAME_SIZE){
+		strcpy(header->name, path);
+		header->prefix[0] = '\0';
+	}
+
+	else if(path_len < MAX_NAME_SIZE * 2){ 
+		strncpy(header->prefix, path, MAX_NAME_SIZE);
+		header->prefix[MAX_NAME_SIZE - 1] = '\0';
+		strncpy(header->name, &path[MAX_NAME_SIZE - 1], MAX_NAME_SIZE);
+		header->name[MAX_NAME_SIZE - 1] = '\0';
+		}
+
+	 else
+		 printf("%s", EXC_NAME_SIZE);
+
+}
+
 header_t *create_header(char *path)
 {
-	//char path[] = "text.txt";
 	header_t *header;
 	header = (header_t *)malloc(sizeof(header_t));
 
 	struct stat stats;
 	if (stat(path, &stats) == 0)
 	{
-		strcpy(header->name, path);
+
+    add_name(header, path);
 		add_mode(header, stats);
 		file_info(header, stats);
 	}

--- a/src/my_tar.c
+++ b/src/my_tar.c
@@ -36,6 +36,7 @@ int main(int argc, char *argv[])
         header = create_header(argv[i]);
     }
 
+    printf("name: %s\n prefix: %s\n", header->name, header->prefix);
     printf("mode in char(octal): %s\nUSER ID: %s\nGROUP OWNER ID: %s\nSize: %s\nLink: %s\n", header->mode, header->uid, header->gid, header->size, header->linkname);
 
     free(header);

--- a/src/my_tar.h
+++ b/src/my_tar.h
@@ -31,6 +31,7 @@ typedef struct posix_header
   char gname[32];     /* 297 */
   char devmajor[8];   /* 329 */
   char devminor[8];   /* 337 */
+  // prefer to alow longer names
   char prefix[155];   /* 345 */
                       /* 500 */
 } header_t;
@@ -38,6 +39,7 @@ typedef struct posix_header
 #define NUM_MODES 9
 #define OCTAL 8
 #define DECIMAL 10
+#define MAX_NAME_SIZE 100
 
 // VALUES IN OCTAL
 #define TUREAD 00400  /* read by owner */
@@ -82,6 +84,7 @@ typedef enum
 #define F_NOT_FOUND "my_tar: Refusing to read archive contents from terminal (missing -f option?)\n"
 #define F_ERROR "You must specify one of the the following options -c -r -t -u -x\n"
 #define NULL_OPT "my_tar: Error is not recoverable: exiting now\n"
+#define EXC_NAME_SIZE "my_tar: Filename exceeds maximum length of 200\n"
 
 option_t check_option(char **format);
 

--- a/test_files/prefixtestprefixtestprefixtestprefixtestprefixtestprefixtestprefixtestprefixtestprefixtestprefixtestprefixtestprefixtestprefixtesta.txt
+++ b/test_files/prefixtestprefixtestprefixtestprefixtestprefixtestprefixtestprefixtestprefixtestprefixtestprefixtestprefixtestprefixtestprefixtesta.txt
@@ -1,0 +1,3 @@
+this file name is ridiculously long to test if prefix is working.
+
+names with more than 100 chars will use the prefix field to to store the extra chars


### PR DESCRIPTION
@khalilmasri 
The  `header->name` field can only 100 chars. If the filename exceeds that we will prefix the name using the` header->prefix` field. 

1.  I created some logic that checks the size of  `path`. If the length is less than 100 char then `prefix[0] = '\0'` otherwise prefix takes the first 100 chars and name the remaining chars.
2.  I added a `printf` in main to check for the name and prefix split. 
3.  I created a file with a ridiculously long filename in `test_files/` to test split.
4.  Added a couple of TODO:  to double-check based on tar documentation. 

<img width="1464" alt="Screenshot 2021-06-24 at 19 43 44" src="https://user-images.githubusercontent.com/53109089/123308951-9a591380-d524-11eb-9b40-368c6b831aa7.png">
