### PR TITLE
Header typeflag

### DIFF
--- a/src/file_handling.c
+++ b/src/file_handling.c
@@ -34,6 +34,7 @@ void file_info(header_t *header, struct stat stats)
 
 void add_filetype(header_t *header, struct stat stats)
 {
+
 	if(S_ISDIR(stats.st_mode))
 		 header->typeflag = DIRTYPE; 
 	else if(S_ISREG(stats.st_mode))

--- a/src/file_handling.c
+++ b/src/file_handling.c
@@ -31,6 +31,24 @@ void file_info(header_t *header, struct stat stats)
 	my_itoa(header->linkname, stats.st_nlink, DECIMAL);
 }
 
+
+void add_filetype(header_t *header, struct stat stats)
+{
+	if(S_ISDIR(stats.st_mode))
+		 header->typeflag = DIRTYPE; 
+	else if(S_ISREG(stats.st_mode))
+		header->typeflag = REGTYPE;
+	else if(S_ISCHR(stats.st_mode))
+		header->typeflag =CHRTYPE;
+	else if(S_ISBLK(stats.st_mode))
+		header->typeflag = BLKTYPE;
+	else if(S_ISFIFO(stats.st_mode))
+		header->typeflag = FIFOTYPE;
+	else if(S_ISLNK(stats.st_mode))
+		header->typeflag = SYMTYPE;
+
+}
+
 void add_mode(header_t *header, struct stat stats)
 {
 // ->  TODO:	The mode field provides nine bits specifying file permissions and three bits to specify the Set UID, Set GID, and Save Text (sticky) modes.

--- a/src/my_itoa.c
+++ b/src/my_itoa.c
@@ -22,7 +22,6 @@ void my_itoa(char *str, int num, int base)
         str[idx] = '0';
         return;
 
-        // negative with base 10 only
     }
 
     while (num != 0)

--- a/src/my_tar.c
+++ b/src/my_tar.c
@@ -37,6 +37,7 @@ int main(int argc, char *argv[])
     }
 
     printf("name: %s\n prefix: %s\n", header->name, header->prefix);
+    printf("type %c\n", header->typeflag);
     printf("mode in char(octal): %s\nUSER ID: %s\nGROUP OWNER ID: %s\nSize: %s\nLink: %s\n", header->mode, header->uid, header->gid, header->size, header->linkname);
 
     free(header);

--- a/src/my_tar.h
+++ b/src/my_tar.h
@@ -31,7 +31,6 @@ typedef struct posix_header
   char gname[32];     /* 297 */
   char devmajor[8];   /* 329 */
   char devminor[8];   /* 337 */
-  // prefer to alow longer names
   char prefix[155];   /* 345 */
                       /* 500 */
 } header_t;
@@ -90,10 +89,13 @@ typedef enum
   ERRORF
 } bool_t;
 
+// ERRS
 #define F_NOT_FOUND "my_tar: Refusing to read archive contents from terminal (missing -f option?)\n"
 #define F_ERROR "You must specify one of the the following options -c -r -t -u -x\n"
 #define NULL_OPT "my_tar: Error is not recoverable: exiting now\n"
 #define EXC_NAME_SIZE "my_tar: Filename exceeds maximum length of 200\n"
+#define STAT_ERR "Unable to read"
+#define FLAGTYPE_ERR "File type not recognized. Setting as regular file."
 
 option_t check_option(char **format);
 

--- a/src/my_tar.h
+++ b/src/my_tar.h
@@ -52,20 +52,16 @@ typedef struct posix_header
 #define TOWRITE 00002 /* write by other */
 #define TOEXEC 00001  /* execute/search by other */
 
-#define NA 00000 /* 0 if non applicable */
-
 /* typeflag field. */
 #define REGTYPE  '0'            /* regular file */
 #define AREGTYPE '\0'           /* regular file */
 #define LNKTYPE  '1'            /* link */
 #define SYMTYPE  '2'            /* reserved */
-#define CHRTYPE  '3'            /* character special */
+#define CHRTYPE  '4'            /* character special */
 #define BLKTYPE  '4'            /* block special */
 #define DIRTYPE  '5'            /* directory */
 #define FIFOTYPE '6'            /* FIFO special */
 #define CONTTYPE '7'            /* reserved */
-
-
 
 header_t *create_header(char *path);
 

--- a/src/my_tar.h
+++ b/src/my_tar.h
@@ -42,8 +42,8 @@ typedef struct posix_header
 #define MAX_NAME_SIZE 100
 
 // VALUES IN OCTAL
-#define TUREAD 00400  /* read by owner */
-#define TUWRITE 00200 /* write by owner */
+#define TUREAD 00401  /* read by owner */
+#define TUWRITE 00202 /* write by owner */
 #define TUEXEC 00100  /* execute/search by owner */
 #define TGREAD 00040  /* read by group */
 #define TGWRITE 00020 /* write by group */
@@ -53,6 +53,19 @@ typedef struct posix_header
 #define TOEXEC 00001  /* execute/search by other */
 
 #define NA 00000 /* 0 if non applicable */
+
+/* typeflag field. */
+#define REGTYPE  '0'            /* regular file */
+#define AREGTYPE '\0'           /* regular file */
+#define LNKTYPE  '1'            /* link */
+#define SYMTYPE  '2'            /* reserved */
+#define CHRTYPE  '3'            /* character special */
+#define BLKTYPE  '4'            /* block special */
+#define DIRTYPE  '5'            /* directory */
+#define FIFOTYPE '6'            /* FIFO special */
+#define CONTTYPE '7'            /* reserved */
+
+
 
 header_t *create_header(char *path);
 


### PR DESCRIPTION
- Added typeflag as folows:

```
REGTYPE  '0'            /* regular file */
AREGTYPE '\0'           /* regular file */
LNKTYPE  '1'            /* link */
SYMTYPE  '2'            /* reserved */
CHRTYPE  '3'            /* character special */
BLKTYPE  '4'            /* block special */
DIRTYPE  '5'            /* directory */
FIFOTYPE '6'            /* FIFO special */
```

- Still need to work on
`CONTTYPE '7'            /* reserved */`

- Fixed prefix. Now  program only adds chars overflowing the 100 char limit in `header->name`
