### PR TITLE
refactor option.c

### DIFF
--- a/src/archive.c
+++ b/src/archive.c
@@ -35,31 +35,31 @@ header_t *tar(char *path, FILE *dest)
 
 }
 
-// TODO: alternatively we can just pass in the header
-header_t *archive(char *path, char **argv, int argc)
+int archive(char **paths, size_t paths_len, header_t *headers[])
 {
-	header_t *header;
 	struct stat stats;
-	FILE *dest = fopen(path, "wb");
-	int fd,
-		index = argv[1][0] == '-' ? 3 :  2;
+	FILE *dest = fopen(paths[0], "wb");
+	int fd; 
+	size_t index = 1;
 	if (dest == NULL)
 	{
-		printf("ERROR\n");
+		printf("Error creating archive file\n");
 	//	exit(1);
-	return header;
+	return -1;
 	}
-	while (index < argc)
+
+	while (index < paths_len)
 	{
-		// TODO: need to look into creating multiple headers and free them. maybe the logic ouside this function.
-		fd = open(argv[index], O_APPEND);
+		fd = open(paths[index], O_APPEND);
 		lseek(fd, 0, SEEK_SET);
-    header = tar(argv[index], dest);
+		// header per file
+		headers[index - 1] = tar(paths[index], dest);
 		index++;
 		close(fd);
 	}
 
 	fclose(dest);
 
-	return header;
+	return index - 1;
+
 }

--- a/src/my_tar.c
+++ b/src/my_tar.c
@@ -37,7 +37,9 @@ int main(int argc, char *argv[])
 
     // prepare paths for ingest
     int path_start_index = find_paths_start_index(argv);
+    // offset argv to path_start_index. Store in paths pointer.
     paths = argv + path_start_index;
+    // get the actual length of the paths array.
     size_t paths_len = argc  - path_start_index;
     bool_t is_tar_valid = validate_tar_extention(paths[0]);
 
@@ -53,9 +55,9 @@ int main(int argc, char *argv[])
         return 0;
     }
 
+    // archive returns the number of headers it created
     header_t *headers[paths_len - 1];
     int num_headers = archive(paths, paths_len, headers);
-
 
     // search fo 'd' for debug mode
     bool_t is_debug = search_flag(argv, 'd');

--- a/src/my_tar.c
+++ b/src/my_tar.c
@@ -22,11 +22,11 @@
 int main(int argc, char *argv[])
 {
 
-    // check_option(argv);
+     check_option(argv);
     //
     if (argc < 2)
         return 0;
-
+/*
     header_t *header;
 
     if(argv[1][0] == '-' && argv[1][1] == 'd'){ 
@@ -41,10 +41,9 @@ int main(int argc, char *argv[])
         header =  archive(argv[1], argv, argc);
     }
 
-
     //  archive(argv[1], argv, argc);
 
     free(header);
-
+*/
     return 0;
 }

--- a/src/my_tar.c
+++ b/src/my_tar.c
@@ -22,28 +22,48 @@
 int main(int argc, char *argv[])
 {
 
-     check_option(argv);
-    //
-    if (argc < 2)
+    // search for -s  for skipping options
+    char **paths;
+    option_t options;
+    bool_t is_skip_options = search_flag(argv, 's');
+    if(is_skip_options == FALSE){
+        // check for options
+        options = check_option(argv);
+        if(options == ERROROPT || options == MISSING_F || options == NONE)
+            return 0;
+    }
+    else
+        printf("skipping options for debug.\n");
+
+    // prepare paths for ingest
+    int path_start_index = find_paths_start_index(argv);
+    paths = argv + path_start_index;
+    size_t paths_len = argc  - path_start_index;
+    bool_t is_tar_valid = validate_tar_extention(paths[0]);
+
+    // return error with wrong extention
+    if(is_tar_valid == FALSE){
+        printf("Archives must have a .tar extention.\n");
         return 0;
-/*
-    header_t *header;
-
-    if(argv[1][0] == '-' && argv[1][1] == 'd'){ 
-        header =  archive(argv[2], argv, argc);
-        debug_header(header);
     }
-    else if(argv[1][0] == '-') {
-        printf("invalid option\n");
+
+    // didn't provide a path to archive
+    if(paths_len == 1){
+        printf("You must provide a ,tar file and a path to file to archive.\n");
         return 0;
     }
-    else {
-        header =  archive(argv[1], argv, argc);
-    }
 
-    //  archive(argv[1], argv, argc);
+    header_t *headers[paths_len - 1];
+    int num_headers = archive(paths, paths_len, headers);
 
-    free(header);
-*/
+
+    // search fo 'd' for debug mode
+    bool_t is_debug = search_flag(argv, 'd');
+    if(is_debug == TRUE)
+        debug_header(headers[0]);
+
+    for(int i = 0; i < num_headers; i++) 
+        free(headers[i]);
+
     return 0;
 }

--- a/src/my_tar.h
+++ b/src/my_tar.h
@@ -112,6 +112,7 @@ typedef enum
   u,
   x,
   NONE,
+  MISSING_F,
   ERROROPT
 } option_t;
 
@@ -123,8 +124,8 @@ typedef enum
 } bool_t;
 
 // ERRS
-#define F_NOT_FOUND "my_tar: Refusing to read archive contents from terminal (missing -f option?)\n"
-#define F_ERROR "You must specify one of the the following options -c -r -t -u -x\n"
+#define MISSING_F_ERR "my_tar: Refusing to read archive contents from terminal (missing -f option?)\n"
+#define MISSING_OPT_ERR "You must specify one of the the following options -c -r -t -u -x\n"
 #define NULL_OPT "my_tar: Error is not recoverable: exiting now\n"
 #define EXC_NAME_SIZE "my_tar: Filename exceeds maximum length of 200\n"
 #define STAT_ERR "Unable to read"

--- a/src/my_tar.h
+++ b/src/my_tar.h
@@ -98,11 +98,6 @@ typedef struct posix_header
                               /* 500 */
 } header_t;
 
-header_t *create_header(char *path);
-void debug_header(header_t *header);
-
-
-/* ========================================================================= */
 
 typedef enum
 {
@@ -111,6 +106,7 @@ typedef enum
   t,
   u,
   x,
+  d,
   NONE,
   MISSING_F,
   ERROROPT
@@ -120,8 +116,9 @@ typedef enum
 {
   FALSE,
   TRUE,
-  ERRORF
 } bool_t;
+
+typedef enum {tar_mode, stat_mode}modes_t;
 
 // ERRS
 #define MISSING_F_ERR "my_tar: Refusing to read archive contents from terminal (missing -f option?)\n"
@@ -131,29 +128,27 @@ typedef enum
 #define STAT_ERR "Unable to read"
 #define FLAGTYPE_ERR "File type not recognized. Setting as regular file."
 
-option_t check_option(char **format);
-
-
-/* ========================================================================= */
 
 #define MODES_ARR_LEN 9
-typedef enum {tar_mode, stat_mode}modes_t;
 
+
+// Helpers
 int *create_bytes_offset(void);
 int *create_modes(modes_t type);
 void fill_zeros(char *field, int len, int total_len) ;
 int my_itoa(char *str, int num, int base);
 int decimal_to_octal(int decimal);
-
-
-/* ========================================================================= */
-
-header_t *archive(char *path, char **argv, int argc);
-
-
-/* ========================================================================= */
-
 int my_ls_tar(char *path);
 int check_byte(int block);
+void debug_header(header_t *header);
+
+// main calbacks
+header_t *create_header(char *path);
+int archive(char **paths, size_t paths_len, header_t *headers[]);
+option_t check_option(char **format);
+
+bool_t search_flag(char **argv, char flag);
+int find_paths_start_index(char **argv);
+bool_t validate_tar_extention(char *path);
 
 #endif

--- a/src/option.c
+++ b/src/option.c
@@ -89,6 +89,14 @@ option_t search_flag_f(option_t flag_opt, char *str)
 	return has_flag_f ? flag_opt :  MISSING_F;
 }
 
+/*
+ *
+ *
+ 		- HELPER: Prints error depending on error type in flag_opt
+
+																																	*/
+
+
 
 void print_error(option_t flag_opt)
 {
@@ -101,7 +109,6 @@ void print_error(option_t flag_opt)
 	if(flag_opt == NONE)
 		printf("%s", NULL_OPT);
 }
-
 
 
 /*

--- a/src/option.c
+++ b/src/option.c
@@ -11,6 +11,9 @@ int search_dash(char *str)
 			has_dash = TRUE;
 			break;
 		}
+		// if not a space then not an option
+		else if(str[index] != ' ')
+			break;
 		else
 			index++;
 	}
@@ -80,6 +83,10 @@ void print_error(option_t flag_opt)
 		printf("%s", NULL_OPT);
 }
 
+
+
+
+
 /*
  * =====================================================================================
  *
@@ -94,8 +101,6 @@ void print_error(option_t flag_opt)
  *    
  * =====================================================================================
  */
-
-
 
 option_t check_option(char **argv)
 {
@@ -116,7 +121,7 @@ option_t check_option(char **argv)
 				flag_opt = select_option(argv[index][pos + 1], flag_opt);
 			}
 			else {
-			// split options: -c -f	
+				// split options: -c -f	
 				flag_opt = select_option(argv[index][pos + 1], flag_opt);
 				if(flag_opt != ERROROPT){
 					char *argv_temp = argv[index];
@@ -127,7 +132,67 @@ option_t check_option(char **argv)
 		index++;
 	}
 
-	 print_error(flag_opt);
-
+	print_error(flag_opt);
 	return flag_opt;
 }
+
+/*
+ * =====================================================================================
+ *
+ *   SEARCH FLAG																																										     
+ *   																									                     													 
+ *    -  Searches for an specifc flag starting with a dash. E.G -d, -s.
+ *
+ *    
+ * =====================================================================================
+ */
+
+
+bool_t search_flag(char **argv, char flag)
+{
+	int index = 1;
+	bool_t found_flag = FALSE;
+
+	while(argv[index]){
+		int pos =	search_dash(argv[index]);
+		if(pos >= 0 && argv[index][pos + 1] == flag)
+			found_flag = TRUE;
+
+		index++;
+	}
+	return found_flag;
+}
+
+int find_paths_start_index(char **argv)
+{
+
+	int index = 1;
+	while(argv[index]){
+		int pos =	search_dash(argv[index]);
+		//  not an option
+		if(pos < 0)
+			break;
+
+		index++;
+	}
+	return index;
+}
+
+bool_t validate_tar_extention(char *path)
+{
+	size_t len = strlen(path);
+	bool_t is_valid = TRUE;
+	int ext_index = 3;
+	char ext[5] = ".tar";
+
+	for(int path_index = len - 1; path_index >= (int)len - ext_index; path_index--)
+	{
+		if(path[path_index] != ext[ext_index])
+			is_valid = FALSE;
+
+		ext_index--;	
+	}
+	return is_valid;
+}
+
+

--- a/src/option.c
+++ b/src/option.c
@@ -1,94 +1,133 @@
 #include "my_tar.h"
 
-option_t check_spam(option_t flag)
+int search_dash(char *str)
 {
-	option_t check_flag = NONE;
+	bool_t has_dash = FALSE;
+	int index = 0;
 
-	if (flag == NONE)
-		return check_flag;
-	else
-		return check_flag = ERROROPT;
+	while(str[index] != '\0'){
+		if(str[index] == '-')	
+		{
+			has_dash = TRUE;
+			break;
+		}
+		else
+			index++;
+	}
+	return has_dash ? index : -1;
 }
 
-bool_t check_f(bool_t flag_f, option_t flag_opt, char **format, int index)
+option_t select_option(char flag, option_t flag_opt)
 {
-	if (flag_opt == NONE)
-		if (format[index][1] == 'f')
-			return ERRORF;
-
-	if (flag_opt != NONE && format[index][1] == 'f')
-		return TRUE;
-
-	if (flag_f == FALSE && format[index][2] == 'f')
-		return TRUE;
-
-	if (flag_f == TRUE)
-		return ERRORF;
-
-	return FALSE;
-}
-
-option_t error_handler(bool_t flag_f, option_t flag_opt)
-{
-	if (flag_f == FALSE)
+	switch (flag)
 	{
-		printf(F_NOT_FOUND);
-		flag_opt = ERROROPT;
+		case 'c':
+			flag_opt = c;
+			break;
+		case 't':
+			flag_opt = t;
+			break;
+		case 'r':
+			flag_opt = r;
+			break;
+		case 'u':
+			flag_opt = u;
+			break;
+		case 'x':
+			flag_opt = x;
+			break;
+		default:
+			flag_opt = ERROROPT;
 	}
-	if (flag_f == ERRORF)
-	{
-		printf(F_ERROR);
-		flag_opt = ERROROPT;
-	}
-	if (flag_opt == NONE || flag_opt == ERROROPT)
-	{
-		printf(NULL_OPT);
-	}
-
 	return flag_opt;
 }
 
-option_t check_option(char **format)
+
+
+option_t search_flag_f(option_t flag_opt, char *str)
+{
+	bool_t has_flag_f = FALSE;
+	int pos = search_dash(str);
+
+	if(pos >= 0)
+	{
+		int i = pos;
+		while(str[i] != '\0'){
+
+			if (str[i] == 'f'){
+				has_flag_f = TRUE;
+				break;
+			}
+			i++;
+		}
+	}
+	else 
+		return MISSING_F;
+
+	return has_flag_f ? flag_opt :  MISSING_F;
+}
+
+
+void print_error(option_t flag_opt)
+{
+	if(flag_opt == MISSING_F)
+		printf("%s", MISSING_F_ERR);
+
+	if(flag_opt == ERROROPT)
+		printf("%s", MISSING_OPT_ERR);
+
+	if(flag_opt == NONE)
+		printf("%s", NULL_OPT);
+}
+
+/*
+ * =====================================================================================
+ *
+ *   CHECK OPTION																																										     
+ *   																									                     													 
+ *    - Parses trough argv for options and return the select options 
+ *    - there is not default options. User must select one of the following otheise an error will be returned
+ *    *** [-c] [-u] [-t] [-x]
+ *    - Options must be accompanied by [-f] otherwise program will return an error.
+ *    - ERROR: function will print error message but return error type to be handled outside this function
+ *
+ *    
+ * =====================================================================================
+ */
+
+
+
+option_t check_option(char **argv)
 {
 	int index = 1;
-
 	option_t flag_opt = NONE;
-	bool_t flag_f = FALSE;
 
-	while (format[index])
+	while (argv[index])
 	{
-		if (format[index][0] == '-' && (flag_opt = check_spam(flag_opt)) == NONE)
+		if(flag_opt != NONE)
+			break;
+		// returns -1 if not found
+		int pos = search_dash(argv[index]);
+		if (pos >= 0) 
 		{
-			if (strlen(format[index]) == 2 || (strlen(format[index]) == 3 && format[index][2] == 'f'))
-			{
-				switch (format[index][1])
-				{
-				case 'c':
-					flag_opt = c;
-					break;
-				case 't':
-					flag_opt = t;
-					break;
-				case 'r':
-					flag_opt = r;
-					break;
-				case 'u':
-					flag_opt = u;
-				case 'x':
-					flag_opt = x;
-					break;
+			size_t len = strlen(argv[index]); 
+			// options together: -cf, -uf 	
+			if (len >= 2 && argv[index][pos + 2] == 'f'){
+				flag_opt = select_option(argv[index][pos + 1], flag_opt);
+			}
+			else {
+			// split options: -c -f	
+				flag_opt = select_option(argv[index][pos + 1], flag_opt);
+				if(flag_opt != ERROROPT){
+					char *argv_temp = argv[index];
+					flag_opt = search_flag_f(flag_opt, argv_temp + pos);
 				}
 			}
-			else
-				flag_opt = ERROROPT;
 		}
-
-		flag_f = check_f(flag_f, flag_opt, format, index);
-
 		index++;
 	}
 
-	flag_opt = error_handler(flag_f, flag_opt);
+	 print_error(flag_opt);
 
 	return flag_opt;
 }

--- a/src/option.c
+++ b/src/option.c
@@ -1,5 +1,11 @@
 #include "my_tar.h"
 
+/*
+ *
+ *
+ 		- HELPER: Looks for the dash char(-) in a string.
+																																			*/
+
 int search_dash(char *str)
 {
 	bool_t has_dash = FALSE;
@@ -19,6 +25,13 @@ int search_dash(char *str)
 	}
 	return has_dash ? index : -1;
 }
+
+/*
+ *
+ *
+ 		- HELPER: select option. Returns ERROROPT if option is not found.
+
+																																		*/
 
 option_t select_option(char flag, option_t flag_opt)
 {
@@ -45,6 +58,12 @@ option_t select_option(char flag, option_t flag_opt)
 	return flag_opt;
 }
 
+/*
+ *
+ *
+ 		- HELPER: searches for a -f flag. flag_opt to missing_f in case of failure
+
+																																	*/
 
 
 option_t search_flag_f(option_t flag_opt, char *str)
@@ -82,8 +101,6 @@ void print_error(option_t flag_opt)
 	if(flag_opt == NONE)
 		printf("%s", NULL_OPT);
 }
-
-
 
 
 
@@ -163,6 +180,20 @@ bool_t search_flag(char **argv, char flag)
 	return found_flag;
 }
 
+/*
+ * =====================================================================================
+ *
+ *   FIND PATHS START INDEX
+ *   																									                     													 
+ *    - looks for the starting position of the paths arguments in relation to argv. 
+ *    - If function returns 3, the first path passed in starts at argv[3]
+ *
+ *    
+ * =====================================================================================
+ */
+
+
+
 int find_paths_start_index(char **argv)
 {
 
@@ -177,6 +208,19 @@ int find_paths_start_index(char **argv)
 	}
 	return index;
 }
+
+/*
+ * =====================================================================================
+ *
+ *   VALIDATE EXTENTION
+ *   																									                     													 
+ *    -  searchs for an ending .tar extention in the first path passed in
+ *    -  returns FALSE if function fails to validate extention
+ *
+ *    
+ * =====================================================================================
+ */
+
 
 bool_t validate_tar_extention(char *path)
 {


### PR DESCRIPTION
I refactored the `option.c`. I think I made it more straightforward as well as created new functionality.   I aimed to reduce a bit the logic complexity and keep the if statements conditions more readable.

`option.c` now will check if there are any empty spaces before options. Just in case the user makes a mistake when type in.

options works for combined flags `-cf` as well as separated flags `-c  -f`.

so if user types in :  `/.my_tar  <space><space><space>  -cf  file.tar /path-to-file` it will still work.

The function `check_options` now returns the following error types: 
  `NONE` - missing option
  `MISSING_F ` -  option by missing `-f`
  ` ERROROPT` - wrong option

main is checking for option errors and will return early if any of these errors occur.

Additional validation for the options and paths passed in are:
- if the user doesn't enter a valid .tar file program returns an error
- if the user doesn't enter a valid path to archive program returns an error.

Additional options:

-  `-s` will skip parsing the options so you won't get any errors. Let's use this flag and avoid commenting code moving forward. 
-  `-d` will run in debug mode.  you can combine these flags together like so `-d -s` but `-ds` will NOT work.
-   normal flags on debug mode also work like so `-cf -d` but  `-cfd` will NOT work.  
-  debug mode and skip mode are for development only. 

Note that every file archiving will have its own header. For this reason, I reworked the `archive` function so it stored all the headers in an array and returns the number of headers for later use. 

Those arrays are then later freed in main.

Functions are commented in `option.c` as well as on main.  I like the idea of having our main function telling the story of what is going on within our program. 
1. Check options
2. Retrieve paths
2. Check for input errors
3. Archive and return header
and so on....

 Please check the code and functionality. 
